### PR TITLE
Fix empty queries

### DIFF
--- a/enhanced-post-cache.php
+++ b/enhanced-post-cache.php
@@ -126,6 +126,10 @@ class Enhanced_Post_Cache {
 			$sql                = '';
 			$this->found_posts  = $cache['found_posts'];
 			$this->all_post_ids = $cache['post_ids'];
+		} else {
+			// If no cache found, reset class properties. 
+			$this->found_posts  = 0;
+			$this->all_post_ids = false;
 		}
 
 		return $sql;


### PR DESCRIPTION
If a cache is not found, then reset the class property back to default values. 